### PR TITLE
Fix empty timezones duplicate key

### DIFF
--- a/src/TimeZoneConverter/TZConvert.cs
+++ b/src/TimeZoneConverter/TZConvert.cs
@@ -328,7 +328,7 @@ namespace TimeZoneConverter
 #else
             systemTimeZones = TimeZoneInfo.GetSystemTimeZones();
 #endif
-            return systemTimeZones.ToDictionary(x => x.Id, x => x, StringComparer.OrdinalIgnoreCase);
+            return systemTimeZones.Where(x => !String.IsNullOrWhiteSpace(x.Id)).ToDictionary(x => x.Id, x => x, StringComparer.OrdinalIgnoreCase);
         }
 
 #if NETSTANDARD


### PR DESCRIPTION
According to https://docs.microsoft.com/en-us/dotnet/api/system.timezoneinfo.getsystemtimezones?view=net-6.0#remarks if some issue with registry read happens -> timezones will init with empty ID value, if more than 1 timezone will have such issue -> that will result in duplicate key exception.