### PR TITLE
Duplicate ID in TimeZoneInfo

### DIFF
--- a/src/TimeZoneConverter/TZConvert.cs
+++ b/src/TimeZoneConverter/TZConvert.cs
@@ -328,7 +328,7 @@ namespace TimeZoneConverter
 #else
             systemTimeZones = TimeZoneInfo.GetSystemTimeZones();
 #endif
-            return systemTimeZones.Where(x => !String.IsNullOrWhiteSpace(x.Id)).ToDictionary(x => x.Id, x => x, StringComparer.OrdinalIgnoreCase);
+            return systemTimeZones.Distinct(new TimeZoneIdEqualityComparer()).ToDictionary(x => x.Id, x => x, StringComparer.OrdinalIgnoreCase);
         }
 
 #if NETSTANDARD
@@ -355,5 +355,20 @@ namespace TimeZoneConverter
             }
         }
 #endif
+        private class TimeZoneIdEqualityComparer : IEqualityComparer<TimeZoneInfo>
+        {
+            public bool Equals(TimeZoneInfo x, TimeZoneInfo y)
+            {
+                if (ReferenceEquals(x, y)) return true;
+                if (ReferenceEquals(x, null)) return false;
+                if (ReferenceEquals(y, null)) return false;
+                return x.Id.Equals(y.Id, StringComparison.OrdinalIgnoreCase);
+            }
+
+            public int GetHashCode(TimeZoneInfo obj)
+            {
+                return obj.Id.GetHashCode();
+            }
+        }
     }
 }

--- a/src/TimeZoneConverter/TZConvert.cs
+++ b/src/TimeZoneConverter/TZConvert.cs
@@ -328,7 +328,7 @@ namespace TimeZoneConverter
 #else
             systemTimeZones = TimeZoneInfo.GetSystemTimeZones();
 #endif
-            return systemTimeZones.ToDictionary(x => x.Id, x => x, StringComparer.OrdinalIgnoreCase);
+            return systemTimeZones.Where(x => !String.IsNullOrWhiteSpace(x.Id)).ToDictionary(x => x.Id, x => x, StringComparer.OrdinalIgnoreCase);
         }
 
 #if NETSTANDARD


### PR DESCRIPTION
With current implementation I face this issue:
```CSharp
System.TypeInitializationException: The type initializer for 'TimeZoneConverter.TZConvert' threw an exception. 
---> System.ArgumentException: An item with the same key has already been added.
   at System.ThrowHelper.ThrowArgumentException(ExceptionResource resource)
   at System.Collections.Generic.Dictionary.Insert(TKey key, TValue value, Boolean add)
   at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable source, Func keySelector, Func elementSelector, IEqualityComparer comparer)
   at TimeZoneConverter.TZConvert.GetSystemTimeZones()
   at TimeZoneConverter.TZConvert..cctor()
   at TimeZoneConverter.TZConvert.GetTimeZoneInfo(String windowsOrIanaTimeZoneId)
   ```

According to https://referencesource.microsoft.com/#mscorlib/system/timezoneinfo.cs,2881 there could be 2 Time zone Id with same name but different case. 
However, I clearly understand that registry key may not have subkeys with same name but different case. Yet this issue is reproducing. To mitigate this and prevent same issue in the future, it worth adding such distinct check.