### PR TITLE
Use overloads to avoid breaking change from 5.x

### DIFF
--- a/src/TimeZoneConverter/TimeZoneConverter.csproj
+++ b/src/TimeZoneConverter/TimeZoneConverter.csproj
@@ -8,7 +8,7 @@
     <PackageTags>timezone;time;zone;time zone;iana;tzdb;olson;timezoneinfo,rails</PackageTags>
     <PackageProjectUrl>https://github.com/mattjohnsonpint/TimeZoneConverter</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>6.0.0</Version>
+    <Version>6.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Adding new optional parameter caused an unintended breaking change (see mattjohnsonpint/TimeZoneNames#83).

Replacing with method overloads to fix.