### PR TITLE
Remove redundant verified includes

### DIFF
--- a/test/TimeZoneConverter.Tests/TimeZoneConverter.Tests.csproj
+++ b/test/TimeZoneConverter.Tests/TimeZoneConverter.Tests.csproj
@@ -8,10 +8,4 @@
     <ProjectReference Include="..\..\src\TimeZoneConverter\TimeZoneConverter.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Update="DataVerificationTests.IANA_To_Windows.verified.txt">
-      <DependentUpon>DataVerificationTests.cs</DependentUpon>
-    </None>
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
These occur due to a bug in VS where it incorrectly duplicates dynamic includes when you copy/rename a test file.