### PR TITLE
Enable .NET analyzers and fix issues

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,10 +10,11 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-  </ItemGroup>
+  <PropertyGroup Label="Analysis rules">
+    <AnalysisLevel>latest-Recommended</AnalysisLevel>
+  </PropertyGroup>
 
 </Project>

--- a/src/TimeZoneConverter.DataBuilder/DataExtractor.cs
+++ b/src/TimeZoneConverter.DataBuilder/DataExtractor.cs
@@ -77,13 +77,14 @@ public static class DataExtractor
 
         foreach (var link in tzdbLinks)
         {
-            if (!data.ContainsKey(link.Value))
+            if (!data.TryGetValue(link.Value, out string? value))
             {
-                data.Add(link.Value, link.Key);
+                value = link.Key;
+                data.Add(link.Value, value);
                 continue;
             }
 
-            if (data[link.Value].Trim().Split().Contains(link.Key))
+            if (value.Trim().Split().Contains(link.Key))
             {
                 continue;
             }
@@ -109,7 +110,7 @@ public static class DataExtractor
         foreach (var file in dataFiles)
         {
             var lines = File.ReadLines(Path.Combine(tzdbDirectoryPath, file));
-            foreach (var line in lines.Where(x => x.StartsWith("Link")))
+            foreach (var line in lines.Where(x => x.StartsWith("Link", StringComparison.Ordinal)))
             {
                 var parts = line.Trim().Split(Array.Empty<char>(), StringSplitOptions.RemoveEmptyEntries);
                 var target = parts[1];
@@ -125,7 +126,7 @@ public static class DataExtractor
     {
         var data = new Dictionary<string, IList<string>>();
         var lines = File.ReadLines(Path.Combine(tzdbDirectoryPath, "zone.tab"));
-        foreach (var line in lines.Where(x => !x.StartsWith("#")))
+        foreach (var line in lines.Where(x => !x.StartsWith('#')))
         {
             var parts = line.Trim().Split('\t');
             var territory = parts[0];

--- a/src/TimeZoneConverter.DataBuilder/Downloader.cs
+++ b/src/TimeZoneConverter.DataBuilder/Downloader.cs
@@ -31,7 +31,7 @@ public static class Downloader
 
     public static string GetTempDir()
     {
-        return Path.GetTempPath() + Path.GetRandomFileName().Substring(0, 8);
+        return string.Concat(Path.GetTempPath(), Path.GetRandomFileName().AsSpan(0, 8));
     }
 
     private static async Task DownloadAsync(string url, string dir)

--- a/src/TimeZoneConverter.Posix/PosixTimeZone.cs
+++ b/src/TimeZoneConverter.Posix/PosixTimeZone.cs
@@ -11,6 +11,8 @@ namespace TimeZoneConverter.Posix;
 /// </summary>
 public static class PosixTimeZone
 {
+    private static readonly char[] PosixAbbreviationSplitChars = {'+', '-'};
+
     /// <summary>
     /// Generates a POSIX time zone string from a <see cref="TimeZoneInfo" /> object, for the current year.
     /// Note - only uses only the <see cref="TimeZoneInfo.Id" /> property from the object.
@@ -130,7 +132,7 @@ public static class PosixTimeZone
 
     private static string GetPosixAbbreviation(string abbreviation)
     {
-        return abbreviation.IndexOfAny(new[] {'+', '-'}) != -1 ? "<" + abbreviation + ">" : abbreviation;
+        return abbreviation.IndexOfAny(PosixAbbreviationSplitChars) != -1 ? "<" + abbreviation + ">" : abbreviation;
     }
 
     private static string GetPosixOffsetString(Offset offset)


### PR DESCRIPTION
Enables analyzers for main projects and fixes based on warnings which are now errors. Removed GitHub source link as it comes with SDK out of the box nowadays.